### PR TITLE
#159294934 Add project settings for multiple environments

### DIFF
--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -77,29 +77,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'authors.wsgi.application'
 
-# Database
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-
-db_url = os.getenv("DATABASE_URL")
-parsed_url = urlparse(db_url)
-dbname = parsed_url.path[1:]
-username = parsed_url.username
-hostname = parsed_url.hostname
-pwd = parsed_url.password
-port_number = parsed_url.port
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': dbname,
-        'USER': username,
-        'PASSWORD': pwd,
-        'HOST': hostname,
-        'PORT': port_number,
-    }
-}
-
-
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 

--- a/authors/settings/development.py
+++ b/authors/settings/development.py
@@ -1,0 +1,27 @@
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+from authors.settings.base import *
+
+from urllib.parse import urlparse
+
+db_url = os.getenv("DATABASE_URL")
+
+parsed_url = urlparse(db_url)
+
+dbname = parsed_url.path[1:]
+username = parsed_url.username
+hostname = parsed_url.hostname
+pwd = parsed_url.password
+port_number = parsed_url.port
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': dbname,
+        'USER': username,
+        'PASSWORD': pwd,
+        'HOST': hostname,
+        'PORT': port_number,
+    }
+}

--- a/authors/settings/testing.py
+++ b/authors/settings/testing.py
@@ -1,0 +1,27 @@
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+from authors.settings.base import *
+
+from urllib.parse import urlparse
+
+db_url = os.getenv("TEST_DATABASE_URL")
+
+parsed_url = urlparse(db_url)
+
+dbname = parsed_url.path[1:]
+username = parsed_url.username
+hostname = parsed_url.hostname
+pwd = parsed_url.password
+port_number = parsed_url.port
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': dbname,
+        'USER': username,
+        'PASSWORD': pwd,
+        'HOST': hostname,
+        'PORT': port_number,
+    }
+}

--- a/authors/wsgi.py
+++ b/authors/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authors.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authors.settings.development")
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authors.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authors.settings.base")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ djangorestframework==3.8.2
 docopt==0.6.2
 idna==2.7
 psycopg2==2.7.5
+psycopg2-binary==2.7.5
 PyJWT==1.4.2
 pytz==2018.5
 requests==2.19.1


### PR DESCRIPTION
#### What does this PR do?
Add Django settings to support multiple environments i.e. testing, development.
#### How should this be manually tested?
After cloning the project, the commands to run the project are python
* python manage.py runserver --settings=authors.settings.testing
* python manage.py runserver --settings=authors.settings.development

Using your terminal, add environment variables "DATABASE_URL" and "TEST_DATABASE_URL" and give them the necessary postgres urls.
#### What are the relevant pivotal tracker stories?
#159294934