### PR TITLE
#159557151 Use token generated data for update endpoint 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ db.sqlite3
 
 #DS STORE
 .DS_Store
+
+#Images folder
+profile_image/

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -4,6 +4,8 @@ from authors.apps.authentication.models import User
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from authors.settings.base import SECRET_KEY 
+from authors.apps.authentication.backends import JWTAuthentication
 import json
 from authors.apps.profiles.serializers import (
     UpdateSerializer,ProfileSerializer
@@ -21,12 +23,13 @@ class UserUpdate(APIView):
                 
     
     def put(self,request):
+        jwt = JWTAuthentication()
         if not self.check_empty_input(request.data):
             return Response(data={
                 "error":"One of the input fields is empty."
                 },status=status.HTTP_400_BAD_REQUEST)
 
-        email = request.data.get('email')
+        email = jwt.authenticate(request)[0]
         user = User.objects.filter(email=email)
         updated_user = self.serializer_class().update(user[0], request.data)
         return Response(data=self.serializer_class(updated_user).data,status=status.HTTP_200_OK)

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -142,3 +142,4 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',  
     ),   
 }
+

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -23,6 +23,6 @@ urlpatterns = [
     path('api/', include('authors.apps.articles.urls')),   
 
     path('api/', include('authors.apps.authentication.urls', namespace='authentication')),
-    path('api/profiles', include('authors.apps.profiles.urls', namespace='profiles')),
+    path('api/profiles/', include('authors.apps.profiles.urls', namespace='profiles')),
 ]
 


### PR DESCRIPTION
#### What does this PR do?
Changes the update endpoint to use the user data supplied by the token instead of requiring email to be supplied manually.
#### What are the relevant pivotal tracker stories?
#159557151