### PR TITLE
#160233594 Fetch all articles

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,4 +18,5 @@ omit =
     *email_reg_util*
     *reset_password_util*
     *app_util*
+    */media/*
     

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,9 @@ db.sqlite3
 profile_image/
 #sendgrid file
 sendgrid.env
+
+#media files
+media/
+
+#migrations
+migrations/

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -8,30 +8,34 @@ from statistics import mean
 
 
 class Article(models.Model):
-    title = models.CharField(max_length = 500)
+    title = models.CharField(max_length=500)
     description = models.TextField()
-    slug = models.SlugField(max_length = 255, blank = True)
+    slug = models.SlugField(max_length=255, blank=True)
     body = models.TextField()
-    created_at = models.DateTimeField(editable = False)
-    updated_at  = models.DateTimeField(blank = True, null = True)
-    author = models.ForeignKey(User, related_name = "user_articles", on_delete = models.CASCADE)
-    favorited = models.BooleanField(default = False)
-    favoritesCount = models.IntegerField(default = 0)
-    tags = TaggableManager(blank = True)
-    rating = models.PositiveIntegerField(blank = True, editable = False, null = True)
-    likes = models.ManyToManyField(User,related_name="likes",blank=True)
-    likesCount = models.IntegerField(default = 0)
-    dislikes = models.ManyToManyField(User,related_name="dislikes",blank=True)
-    dislikesCount = models.IntegerField(default = 0)
-    favorites = models.ManyToManyField(User,related_name="favorites",blank=True)
+    created_at = models.DateTimeField(editable=False)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    author = models.ForeignKey(
+        User, related_name="user_articles", on_delete=models.CASCADE)
+    favorited = models.BooleanField(default=False)
+    favoritesCount = models.IntegerField(default=0)
+    tags = TaggableManager(blank=True)
+    rating = models.PositiveIntegerField(blank=True, editable=False, null=True)
+    likes = models.ManyToManyField(User, related_name="likes", blank=True)
+    likesCount = models.IntegerField(default=0)
+    dislikes = models.ManyToManyField(
+        User, related_name="dislikes", blank=True)
+    dislikesCount = models.IntegerField(default=0)
+    favorites = models.ManyToManyField(
+        User, related_name="favorites", blank=True)
 
     def save(self, *args, **kwargs):
         if not self.id:
-            self.slug = slugify(self.title).replace("_","-")
+            self.slug = slugify(self.title).replace("_", "-")
             article_class = self.__class__
             qs_exists = article_class.objects.filter(slug=self.slug)
             if qs_exists:
-                self.slug = self.slug + "-" + str(uuid.uuid4()).replace("_","-")
+                self.slug = self.slug + "-" + \
+                    str(uuid.uuid4()).replace("_", "-")
             self.created_at = timezone.now()
             return super(Article, self).save(*args, **kwargs)
         self.updated_at = timezone.now()
@@ -43,27 +47,31 @@ class Article(models.Model):
     def __str__(self):
         return self.title
 
-class ArticleImage(models.Model):
-    article = models.ForeignKey(Article, related_name = "article_images", on_delete = models.CASCADE)
-    image = models.ImageField()
 
-   
+class ArticleImage(models.Model):
+    article = models.ForeignKey(
+        Article, related_name="article_images", on_delete=models.CASCADE)
+    image = models.ImageField(upload_to='article_images/%Y/%m/%d', blank=True)
+
+
 class Rating(models.Model):
     RATING_CHOICES = (
-    (1,1),
-    (2,2),
-    (3,3),
-    (4,4),
-    (5,5),
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
     )
-    user = models.ForeignKey(User, related_name = "user_article_rating", on_delete = models.CASCADE, blank = True)
-    article = models.ForeignKey(Article, related_name = "article_ratings",on_delete = models.CASCADE, blank = True)
-    amount = models.PositiveIntegerField(choices = RATING_CHOICES)
+    user = models.ForeignKey(
+        User, related_name="user_article_rating", on_delete=models.CASCADE, blank=True)
+    article = models.ForeignKey(
+        Article, related_name="article_ratings", on_delete=models.CASCADE, blank=True)
+    amount = models.PositiveIntegerField(choices=RATING_CHOICES)
 
     class Meta:
         ordering = ('-amount', )
 
-    def av_rating(self,qs_set, new_rating = None):
+    def av_rating(self, qs_set, new_rating=None):
         if new_rating:
             new_qs_set_ratings = [rating.amount for rating in qs_set]
             new_qs_set_ratings.append(new_rating)
@@ -73,30 +81,35 @@ class Rating(models.Model):
 
     def save(self, *args, **kwargs):
         rating_class = self.__class__
-        qs_exists = rating_class.objects.filter(article = self.article).filter(user = self.user)
+        qs_exists = rating_class.objects.filter(
+            article=self.article).filter(user=self.user)
         if not qs_exists:
-            existing_ratings = self.article.article_ratings.all() 
+            existing_ratings = self.article.article_ratings.all()
             if existing_ratings:
-                Article.objects.filter(pk = self.article.id).update(rating = self.av_rating(existing_ratings, self.amount))
+                Article.objects.filter(pk=self.article.id).update(
+                    rating=self.av_rating(existing_ratings, self.amount))
             return super(Rating, self).save(*args, **kwargs)
-        qs_exists.update(amount = self.amount)
+        qs_exists.update(amount=self.amount)
         ratings = self.article.article_ratings.all()
-        Article.objects.filter(pk = self.article.id).update(rating = self.av_rating(ratings))
-        return 
+        Article.objects.filter(pk=self.article.id).update(
+            rating=self.av_rating(ratings))
+        return
 
     def __str__(self):
         return 'Rating of {} on {} by user {}'.format(self.amount, self.article, self.user)
+
+
 class Comment(models.Model):
-    author = models.ForeignKey(User, related_name = "comment_author", on_delete = models.CASCADE)
-    article = models.ForeignKey(Article,related_name = "user_comments", on_delete = models.CASCADE, blank = True)
+    author = models.ForeignKey(
+        User, related_name="comment_author", on_delete=models.CASCADE)
+    article = models.ForeignKey(
+        Article, related_name="user_comments", on_delete=models.CASCADE, blank=True)
     body = models.TextField()
-    created_at = models.DateTimeField(editable = False,auto_now=True)
-    updated_at  = models.DateTimeField(blank = True, null = True,auto_now_add=True)
+    created_at = models.DateTimeField(editable=False, auto_now=True)
+    updated_at = models.DateTimeField(blank=True, null=True, auto_now_add=True)
 
     class Meta:
         ordering = ('-created_at',)
 
     def __str__(self):
         return self.body
-
-

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -5,12 +5,14 @@ from authors.apps.articles.models import Article, Rating, Comment
 from taggit_serializer.serializers import (
     TagListSerializerField, TaggitSerializer)
 from django.utils import timezone
+from .models import ArticleImage
 
 
 class CreateArticleSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     tags = TagListSerializerField(required=False)
     author = serializers.SerializerMethodField()
+    article_images = serializers.SerializerMethodField()
 
     def get_author(self, obj):
         user = {
@@ -20,10 +22,19 @@ class CreateArticleSerializer(TaggitSerializer, serializers.ModelSerializer):
         }
         return user
 
+    def get_article_images(self, obj):
+        image_array = []
+        images = obj.article_images.all()
+
+        for image in images:
+            image_array.append(image.image.url)
+
+        return image_array
+
     class Meta:
         model = Article
         fields = ['slug', 'title', 'description', 'body', 'created_at', 'updated_at',
-                  'author', 'favorited', 'favoritesCount', 'likesCount', 'dislikesCount', 'tags']
+                  'author', 'favorited', 'favoritesCount', 'likesCount', 'dislikesCount', 'tags','article_images']
 
 
 class RateArticleSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/tests/test_fetch_all_articles.py
+++ b/authors/apps/articles/tests/test_fetch_all_articles.py
@@ -1,0 +1,50 @@
+from django.test import TestCase, RequestFactory
+from authors.apps.articles.views import ListAllArticlesAPIView, ArticleCreateAPIView
+from authors.apps.authentication.views import RegistrationAPIView, VerificationAPIView
+
+
+class FetchAllArticlesTestCase(TestCase):
+    def setUp(self):
+
+        self.user = {
+            "user": {
+                "email": "test@gmail.com",
+                "username": "tester",
+                "password": "testpass@word"
+            }
+        }
+
+        self.obj = UtilClass()
+        registered_user = self.obj.get_reg_data(self.user)
+        self.obj.verify_user({"token": registered_user.data["token"]})
+        logged_in_user = self.obj.get_login_data(self.user)
+
+        self.headers = {
+            'HTTP_AUTHORIZATION': 'Token ' + logged_in_user.data["token"]
+        }
+
+        def test_fetch_all_existing_articles(self):
+            article_data = {
+                "title": "This is Postman",
+                "description": "Hello Postman",
+                "body": "Hahahaha",
+                "tags": ["post", "man"]
+            }
+
+            make_article_request = self.factory.post('api/articles', data=json.dumps(
+                article_data), **self.headers, content_type='application/json')
+
+            ArticleCreateAPIView.as_view()(make_article_request)
+
+            request = self.factory.get('api/all/articles/')
+            response = ListAllArticlesAPIView.as_view()(request)
+            self.assertEqual(response.data['results'][count], 1)
+            self.assertEqual(
+                response.data['results']['articles'][0]['title'], "This is Postman")
+
+        def test_fetch_all_from_empty_db(self):
+            request = self.factory.get('api/all/articles/')
+            response = ListAllArticlesAPIView.as_view()(request)
+            self.assertEqual(response.data['results'][count], 0)
+            self.assertEqual(
+                len(response.data['results']['articles']), 0)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -10,6 +10,7 @@ from .views import (
     UpdateArticleAPIView,
     SearchArticlesAPIView,
     DeleteArticleAPIView,
+    ListAllArticlesAPIView,
 )
 
 app_name = "articles"
@@ -24,4 +25,5 @@ urlpatterns = [
     path('articles/<slug>/favorite', FavoriteArticleAPIView.as_view()),
     path('articles/search', SearchArticlesAPIView.as_view()),
     path('articles/<slug>/delete/', DeleteArticleAPIView.as_view()),
+    path('articles/all/', ListAllArticlesAPIView.as_view()),
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -6,7 +6,7 @@ from rest_framework.views import APIView
 from .serializers import CreateArticleSerializer
 from authors.apps.authentication.models import User
 from authors.apps.articles.models import Article, Comment
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from authors.apps.authentication.backends import JWTAuthentication
 from rest_framework.views import APIView
 from rest_framework import status, exceptions
@@ -185,6 +185,15 @@ class SearchArticlesAPIView(ListAPIView):
                         if filter_field == tag.name:
                             filtered_queryset.append(article)
         return filtered_queryset
+
+class ListAllArticlesAPIView(ListAPIView):
+    permission_classes = (AllowAny, )
+    serializer_class = CreateArticleSerializer
+    renderer_classes = (ListArticlesJSONRenderer,)
+    pagination_class = PageNumberPagination
+    def get_queryset(self):
+        articles = Article.objects.all()
+        return articles
 
 
 class UpdateArticleAPIView(UpdateAPIView):

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -143,11 +143,14 @@ REST_FRAMEWORK = {
     'NON_FIELD_ERRORS_KEY': 'error',
 
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'authors.apps.authentication.backends.JWTAuthentication',  
-    ),   
+        'authors.apps.authentication.backends.JWTAuthentication',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 5
 }
 
-EMAIL_BACKEND="djmail.backends.default.EmailBackend"
-DJMAIL_REAL_BACKEND="django.core.mail.backends.console.EmailBackend"
+EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+DJMAIL_REAL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -16,14 +16,18 @@ Including another URLconf
 from django.urls import include, path
 from django.contrib import admin
 from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token, verify_jwt_token
+from django.conf.urls.static import static
+from authors.settings.base import MEDIA_URL, MEDIA_ROOT
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('authors.apps.articles.urls')),   
+    path('api/', include('authors.apps.articles.urls')),
 
-    path('api/', include('authors.apps.authentication.urls', namespace='authentication')),
+    path('api/', include('authors.apps.authentication.urls',
+                         namespace='authentication')),
     path('api/profiles/', include('authors.apps.profiles.urls', namespace='profiles')),
-    path('api/users/', include('authors.apps.follower.urls', namespace = "follows"))
+    path('api/users/', include('authors.apps.follower.urls', namespace="follows"))
 ]
 
+urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)


### PR DESCRIPTION
#### What does this PR do?
This PR adds an endpoint that returns all articles on authors haven by date of creation.
#### Background context
This PR solves the fact that there was no endpoint to return all articles on authors haven. This PR also solves the fact that the articles that were being returned by other endpoints did not return the images/image associated with that article. The articles are now returned in this format:
{
    "results": {
        "count": 1,
        "next": null,
        "previous": null,
        "articles": [
            {
                "slug": "this-is-postman",
                "title": "This is Postman",
                "description": "Postman is goood",
                "body": "Postman api",
                "created_at": "2018-09-03T16:34:46.858071Z",
                "updated_at": "2018-09-03T18:05:10.475674Z",
                "author": {
                    "username": "Guwatudde",
                    "email": "allan.guwatudde@andela.com",
                    "bio": ""
                },
                "favorited": false,
                "favoritesCount": 0,
                "likesCount": 0,
                "dislikesCount": 0,
                "tags": [
                    "music"
                ],
                "article_images": [
                    "/media/article_images/2018/09/03/473023_397573750258322_380083540_o.jpg"
                ]
            }
        ]
    }
}

#### What are the relevant pivotal tracker stories?
[#160233594](https://www.pivotaltracker.com/story/show/160233594)