### PR TITLE
#160613986 Fix commenting bug

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -67,7 +67,7 @@ class CommentCreateAPIView(CreateAPIView):
         user_data = jwt.authenticate(self.request)
         slug = self.kwargs.get(self.look_url_kwarg)
         serializer.save(
-            author=user_data[0], article=get_object_or_404(Article))
+            author=user_data[0], article=get_object_or_404(Article, slug=slug))
 
 class ArticleTextCommentCreateAPIView(CreateAPIView):
     permission_classes = (IsAuthenticated, )


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a commenting bug in the CreateCommentAPIView. 
#### Backgound context
get_object_or_404() was missing the slug filter. So it was cheanged from 
```
get_object_or_404(Articles) 
```
to
```
get_object_or_404(Articles, slug=slug) 
```
#### Pivotal Tracker Story
[#160613986](https://www.pivotaltracker.com/story/show/160613986)